### PR TITLE
RFC: change default directory to `src,ext`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ See [PkgTemplates.jl](https://github.com/invenia/PkgTemplates.jl/blob/master/tes
           files: lcov.info
 ```
 
-One can also specify the directory or directories to use via the `directories` input (which defaults to `src`). E.g.
+One can also specify the directory or directories (comma separated) to use via the `directories` input (which defaults to `src,ext`). E.g.
 ```yaml
 
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: src,examples
+          directories: src,ext,examples
       - uses: codecov/codecov-action@v2
         with:
           files: lcov.info
 ```
-instructs the action to look for coverage information in both `src` and an `examples` folder. Likewise, use
+instructs the action to look for coverage information in `src`, `ext`, and an `examples` folder. Likewise, use
 ```yaml
       - uses: julia-actions/julia-processcoverage@v1
         with:

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   directories:
     description: 'Comma-separated list of directories to look for coverage information (e.g. `src,examples`)'
     required: false
-    default: 'src'
+    default: 'src,ext'
 
 runs:
   using: 'composite'

--- a/main.jl
+++ b/main.jl
@@ -6,7 +6,7 @@ Pkg.add(PackageSpec(name="CoverageTools"))
 
 using CoverageTools
 
-directories = get(ENV, "INPUT_DIRECTORIES", "src")
+directories = get(ENV, "INPUT_DIRECTORIES", "src,ext")
 dirs = filter!(!isempty, split(directories, ","))
 for dir in dirs
     isdir(dir) || error("directory \"$dir\" not found!")


### PR DESCRIPTION
This adds the `ext` directory to the default directories together with `src`. This is the directory where package extensions lives.